### PR TITLE
Add LeadEmail validations

### DIFF
--- a/app/models/lead_email.rb
+++ b/app/models/lead_email.rb
@@ -1,4 +1,30 @@
 class LeadEmail < ApplicationRecord
     belongs_to :lead
-    belongs_to :job_positions
+    belongs_to :job_position
+
+    # global validations
+    validates :email, :email_body, :subject, { 
+        presence: true 
+    }
+
+    # email validations
+    validates :email, {
+        format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i, message: "email format is not valid" },
+    }
+
+    # subject validations
+    validates :subject, {
+        length: { within: 15..70 },
+        format: { with: /\A[a-zA-Z0-9\s]+\z/, message: "only letters, numbers and spaces are allowed" }
+    }
+
+    # email_body validations
+
+    # sent & open validations
+    validates_inclusion_of :sent, :open, :in => [true, false]
+
+    # lead_id validations
+
+    # job_position_id validations
+
 end

--- a/db/migrate/20200716021939_create_lead_emails.rb
+++ b/db/migrate/20200716021939_create_lead_emails.rb
@@ -3,7 +3,7 @@ class CreateLeadEmails < ActiveRecord::Migration[6.0]
     create_table :lead_emails do |t|
       t.string :email, default: "example@example.com", null: false
       t.string :subject, default: "write an eye catching email subject", null: false
-      t.string :email_body, default: "compost an email...", null: false
+      t.text :email_body, default: "compost an email...", null: false
       t.boolean :sent, default: false, null: false
       t.boolean :open, default: false, null: false
       t.integer :lead_id, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,7 +54,7 @@ ActiveRecord::Schema.define(version: 2020_07_16_045054) do
   create_table "lead_emails", force: :cascade do |t|
     t.string "email", default: "example@example.com", null: false
     t.string "subject", default: "write an eye catching email subject", null: false
-    t.string "email_body", default: "compost an email...", null: false
+    t.text "email_body", default: "compost an email...", null: false
     t.boolean "sent", default: false, null: false
     t.boolean "open", default: false, null: false
     t.integer "lead_id", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,3 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
 require File.expand_path('../../spec/instance_helper', __FILE__)
 User.destroy_all
 Board.destroy_all
@@ -13,8 +6,6 @@ Lead.destroy_all
 JobPosition.destroy_all
 LeadEmail.destroy_all
 Company.destroy_all
-
-
 
 user_1 = User.create(InstanceHelper.seed_get_user_params)
 
@@ -28,12 +19,4 @@ lead_1 = Lead.create(InstanceHelper.seed_get_lead_params(column_1.id, company_1.
 
 job_position_1 = JobPosition.create(InstanceHelper.seed_get_job_position_params(user_1.id, company_1.id))
 
-lead_email_1 = LeadEmail.create(
-    email: "example@example.com", 
-    subject: "software Engineer Position",
-    email_body: "Hello #{lead_1.first_name}, I am contacting you regarding to the #{job_position_1.name}", 
-    sent: false, 
-    open: false,
-    lead_id: lead_1.id, 
-    job_position_id: job_position_1.id
-)
+lead_email_1 = LeadEmail.create(InstanceHelper.seed_get_lead_email_params(lead_1.id, job_position_1.id))

--- a/spec/instance_helper.rb
+++ b/spec/instance_helper.rb
@@ -139,7 +139,7 @@ module InstanceHelper
     "company_id" => nil
   }
 
-  def create_lead_instance(column_id, company_id)
+  def create_lead(column_id, company_id)
     params = @@lead_params.clone
     params['column_id'] = column_id
     params['company_id'] = company_id
@@ -262,4 +262,43 @@ module InstanceHelper
     params['company_id'] = company_id
     params
   end
+
+  # <----------- LeadEmail ---------------->
+
+  @@lead_email_params = {
+    "email" => "example@example.com", 
+    "subject" => "1st Software Engineer Position",
+    "email_body" => "Hello, I am contacting you regarding to the front end position", 
+    "sent" => false, 
+    "open" => false,
+    "lead_id" => nil,
+    "job_position_id" => nil
+  }
+
+  def create_lead_email(lead_id, job_position_id)
+    params = @@lead_email_params.clone
+    params['lead_id'] = lead_id
+    params['job_position_id'] = job_position_id
+    LeadEmail.create(params)
+  end
+
+  def get_lead_email_params(lead_id, job_position_id)
+    params = @@lead_email_params.clone
+    params['lead_id'] = lead_id
+    params['job_position_id'] = job_position_id
+    params
+  end
+
+  def lead_email_check_default_value(get_params, value)
+    params = get_params.except!(value)
+    LeadEmail.create(params)
+  end
+
+  def self.seed_get_lead_email_params(lead_id, job_position_id)
+    params = @@lead_email_params.clone
+    params['lead_id'] = lead_id
+    params['job_position_id'] = job_position_id
+    params
+  end
+
 end

--- a/spec/models/lead_email_spec.rb
+++ b/spec/models/lead_email_spec.rb
@@ -1,5 +1,126 @@
-require 'rails_helper'
+require "rails_helper"
 
-# RSpec.describe LeadEmail, type: :model do
-#   pending "add some examples to (or delete) #{__FILE__}"
-# end
+RSpec.describe LeadEmail, type: :model do
+  before(:each) do
+    @user = create_user
+    @company = create_company
+    @board = create_board(@user.id)
+    @column = create_column(@board.id)
+    @lead = create_lead(@column.id, @company.id)
+    @job_position = create_job_position(@user.id, @company.id)
+    @lead_email_params = get_lead_email_params(@lead.id, @job_position.id)
+  end
+
+  subject {
+    # This create an instance of the LeadEmail model
+    # requests_helper.rb
+    create_lead_email(@lead.id, @job_position.id)
+  }
+
+  describe "validations" do
+    describe "email" do
+      it "must be presence" do
+        expect(subject).to be_valid
+        subject.email = nil
+        expect(subject).to_not be_valid
+      end
+      it "must have a default value" do
+        lead_email = lead_email_check_default_value(@lead_email_params, "email")
+        expect(lead_email).to be_valid
+        expect(lead_email["email"]).to eq("example@example.com")
+      end
+      it "must be a valid email format" do
+        expect(subject).to be_valid
+        subject.email = "fernando@wrongformatcom"
+        expect(subject).to_not be_valid
+      end
+    end
+    describe "subject" do
+      it "must be presence" do
+        expect(subject).to be_valid
+        subject.subject = nil
+        expect(subject).to_not be_valid
+      end
+      it "must have a default value" do
+        lead_email = lead_email_check_default_value(@lead_email_params, "subject")
+        expect(lead_email).to be_valid
+        expect(lead_email["subject"]).to eq("write an eye catching email subject")
+      end
+      it "must have a minimum length of 15 characters" do
+        expect(subject).to be_valid
+        subject.subject = "short subject"
+        expect(subject).to_not be_valid
+      end
+      it "must have a maximum length of 70 characters" do
+        expect(subject).to be_valid
+        subject.subject = "this is a very very very long subject that will not have a good open rate"
+        expect(subject).to_not be_valid
+      end
+      it "must have contains only letters, spaces and numbers " do
+        expect(subject).to be_valid
+        subject.subject = "Hello Dear # person %"
+        expect(subject).to_not be_valid
+      end
+    end
+    describe "email_body" do
+      it "must be presence" do
+        expect(subject).to be_valid
+        subject.email_body = nil
+        expect(subject).to_not be_valid
+      end
+      it "must have a default value" do
+        lead_email = lead_email_check_default_value(@lead_email_params, "email_body")
+        expect(lead_email).to be_valid
+        expect(lead_email["email_body"]).to eq("compost an email...")
+      end
+    end
+    describe "sent" do
+      it "must be presence" do
+        expect(subject).to be_valid
+        subject.sent = nil
+        expect(subject).to_not be_valid
+      end
+      it "must have a default value" do
+        lead_email = lead_email_check_default_value(@lead_email_params, "sent")
+        expect(lead_email).to be_valid
+        expect(lead_email["sent"]).to be(false)
+      end
+    end
+    describe "open" do
+      it "must be presence" do
+        expect(subject).to be_valid
+        subject.open = nil
+        expect(subject).to_not be_valid
+      end
+      it "must have a default value" do
+        lead_email = lead_email_check_default_value(@lead_email_params, "open")
+        expect(lead_email).to be_valid
+        expect(lead_email["open"]).to be(false)
+      end
+    end
+    describe "lead_id" do
+      it "must be presence" do
+        expect(subject).to be_valid
+        subject.lead_id = nil
+        expect(subject).to_not be_valid
+      end
+      it "must exist on the DB" do
+        expect(subject).to be_valid
+        subject.lead_id = subject.lead_id + 1
+        expect(subject).to_not be_valid
+      end
+    end
+    describe "job_position_id" do
+      it "must be presence" do
+        expect(subject).to be_valid
+        subject.job_position_id = nil
+        expect(subject).to_not be_valid
+      end
+      it "must exist on the DB" do
+        expect(subject).to be_valid
+        subject.job_position_id = subject.job_position_id + 1
+        expect(subject).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/models/lead_spec.rb
+++ b/spec/models/lead_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Lead, type: :model do
     subject {
         # This create an instance of the Lead model
         # requests_helper.rb
-        create_lead_instance(@column.id, @company.id)
+        create_lead(@column.id, @company.id)
     }
     describe 'Validations' do
       describe 'first_name' do


### PR DESCRIPTION
Key Objectives 
=============================== 
***Objectives***: Write the validations for the LeadEmail model

- Write validations
- Write tests for the validations
- Refactor the validations and the test

Analysis
=============================== 
- ***What are the validations for this modle?***
  - DB validations and Model validations

- ***What are the validations for the email?***
  - must be presence
  - must have a default value
  - must be a valid email format

- ***What are the validations for the subject?***
  - must be presence
  - must have a default value
  - must have a minimum length of 15 characters
  - must have a maximum length of 70 characters
  - must have contains only letters, numbers, and spaces 

- ***What are the validations for the email_body?***
  - must be presence
  - must have a default value

- ***What are the validations for the sent?***
  - must be presence
  - must have a default value

- ***What are the validations for the open?***
  - must be presence
  - must have a default value

- ***What are the validations for the lead_id?***
 - must be presence
 - must exist on the DB

- ***What are the validations for the job_position_id?***
 - must be presence
 - must exist on the DB