### PR TITLE
Add LeadEmail controller

### DIFF
--- a/app/controllers/lead_emails_controller.rb
+++ b/app/controllers/lead_emails_controller.rb
@@ -1,0 +1,58 @@
+class LeadEmailsController < ApplicationController
+  def create
+    lead_email = LeadEmail.new(lead_email_params)
+    if lead_email.valid?
+      lead_email.save
+      render json: { "resp" => LeadEmailSerializer.new(lead_email) }, status: 201
+    else
+      render json: { "resp" => lead_email.errors.messages }, status: 400
+    end
+  end
+
+  def show
+    lead_email = LeadEmail.find_by_id(params[:id])
+    if lead_email
+      render json: { "resp" => LeadEmailSerializer.new(lead_email) }, status: 200
+    else
+      render json: { "resp" => "lead email can't be found" }, status: 404
+    end
+  end
+
+  def update
+    lead_email = LeadEmail.find_by_id(params[:id])
+    if lead_email
+      lead_email.update(lead_email_params)
+      if lead_email.valid?
+        render json: { "resp" => LeadEmailSerializer.new(lead_email) }, status: 200
+      else
+        render json: { "resp" => lead_email.errors.messages }, status: 400
+      end
+    else
+      render json: { "resp" => "lead email can't be found" }, status: 404
+    end
+  end
+
+  def destroy
+    lead_email = LeadEmail.find_by_id(params[:id])
+    if lead_email
+      lead_email.destroy
+      render json: { "resp" => "lead email has been deleted" }, status: 200
+    else
+      render json: { "resp" => "lead email can't be found" }, status: 404
+    end
+  end
+
+  private
+
+  def lead_email_params
+    params.permit(
+      :email,
+      :subject,
+      :email_body,
+      :sent,
+      :open,
+      :lead_id,
+      :job_position_id
+    )
+  end
+end

--- a/app/serializers/lead_email_serializer.rb
+++ b/app/serializers/lead_email_serializer.rb
@@ -1,0 +1,3 @@
+class LeadEmailSerializer < ActiveModel::Serializer
+  attributes :id, :email, :subject, :email_body, :sent, :open, :lead_id, :job_position_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
 
+  post 'lead_emails' => 'lead_emails#create'
+  get 'lead_email/:id' => 'lead_emails#show'
+  put 'lead_email/:id' => 'lead_emails#update'
+  delete 'lead_email/:id' => 'lead_emails#destroy'
+
   post 'job_positions' => 'job_position#create'
   get 'job_position/:id' => 'job_position#show'
   put 'job_position/:id' => 'job_position#update'

--- a/spec/instance_helper.rb
+++ b/spec/instance_helper.rb
@@ -289,6 +289,22 @@ module InstanceHelper
     params
   end
 
+  def get_lead_email_invalid_params(lead_id, job_position_id)
+    params = @@lead_email_params.clone
+    params['lead_id'] = lead_id
+    params['job_position_id'] = job_position_id
+    params["email"] = "example@examplecom" 
+    params
+  end
+
+  def get_lead_email_matcher(lead_id, job_position_id, lead_email_id)
+    params = @@lead_email_params.clone
+    params['lead_id'] = lead_id
+    params['job_position_id'] = job_position_id
+    params['id'] = lead_email_id
+    params
+  end
+
   def lead_email_check_default_value(get_params, value)
     params = get_params.except!(value)
     LeadEmail.create(params)

--- a/spec/requests/lead_email_request_spec.rb
+++ b/spec/requests/lead_email_request_spec.rb
@@ -1,0 +1,165 @@
+require "rails_helper"
+
+RSpec.describe "LeadEmails", type: :request do
+  before(:each) do
+    @user = create_user
+    @company = create_company
+    @board = create_board(@user.id)
+    @column = create_column(@board.id)
+    @lead = create_lead(@column.id, @company.id)
+    @job_position = create_job_position(@user.id, @company.id)
+    @lead_email_params = get_lead_email_params(@lead.id, @job_position.id)
+    @lead_email_invalid_params = get_lead_email_invalid_params(@lead.id, @job_position.id)
+  end
+
+  describe "POST /lead_emails" do
+    context "request is successful" do
+      it "returns a 201 status" do
+        post "/lead_emails", params: @lead_email_params
+
+        expect(response).to have_http_status(201)
+      end
+      it "returns an instance of the LeadEmail model on JSON" do
+        post "/lead_emails", params: @lead_email_params
+        resp_json = JSON.parse(response.body)
+        matcher = get_lead_email_matcher(@lead.id, @job_position.id, resp_json["resp"]["id"])
+
+        expect(resp_json["resp"]).to match(matcher)
+      end
+      it "saves the lead_email on the DB" do
+        db_size = LeadEmail.all.size
+        post "/lead_emails", params: @lead_email_params
+
+        expect(LeadEmail.all.size).to eq(db_size + 1)
+      end
+    end
+    context "request fails" do
+      it "returns a 400 status" do
+        post "/lead_emails", params: @lead_email_invalid_params
+
+        expect(response).to have_http_status(400)
+      end
+      it "returns an object of errors on JSON" do
+        post "/lead_emails", params: @lead_email_invalid_params
+        resp_json = JSON.parse(response.body)
+
+        expect(resp_json["resp"]).to include("email")
+        expect(resp_json["resp"]).to_not match({})
+      end
+    end
+  end
+  describe "GET /lead_email/:id" do
+    before(:each) do
+      post "/lead_emails", params: @lead_email_params
+      @resp_lead_email = JSON.parse(response.body)
+    end
+    context "request is successful" do
+      it "returns a 200 status" do
+        get "/lead_email/#{@resp_lead_email["resp"]["id"]}"
+
+        expect(response).to have_http_status(200)
+      end
+      it "returns an instance of the LeadEmail model on JSON based on the id provided" do
+        get "/lead_email/#{@resp_lead_email["resp"]["id"]}"
+        resp_json = JSON.parse(response.body)
+
+        expect(resp_json["resp"]).to match(@resp_lead_email["resp"])
+      end
+    end
+    context "request fails" do
+      it "returns a 404 status" do
+        get "/lead_email/#{@resp_lead_email["resp"]["id"] + 1}"
+
+        expect(response).to have_http_status(404)
+      end
+      it "returns an error message on JSON" do
+        get "/lead_email/#{@resp_lead_email["resp"]["id"] + 1}"
+        resp_json = JSON.parse(response.body)
+
+        expect(resp_json["resp"]).to eq("lead email can't be found")
+      end
+    end
+  end
+  describe "PUT /lead_email/:id" do
+    before(:each) do
+      post "/lead_emails", params: @lead_email_params
+      @resp_lead_email = JSON.parse(response.body)
+      @update_valid_params = { "email" => "new_email@example.com" }
+      @update_invalid_params = { "email" => "new_invalid_email@examplecom" }
+    end
+    context "request is successful" do
+      it "returns a 200 status" do
+        put "/lead_email/#{@resp_lead_email["resp"]["id"]}", params: @update_valid_params
+
+        expect(response).to have_http_status(200)
+      end
+      it "returns the updated instance of the LeadEmail model on JSON" do
+        put "/lead_email/#{@resp_lead_email["resp"]["id"]}", params: @update_valid_params
+        resp_json = JSON.parse(response.body)
+        matcher = @resp_lead_email["resp"].clone
+        matcher["email"] = @update_valid_params["email"]
+
+        expect(resp_json["resp"]).to match(matcher)
+      end
+    end
+    context "request fails(invalid params)" do
+      it "returns a 400 status" do
+        put "/lead_email/#{@resp_lead_email["resp"]["id"]}", params: @update_invalid_params
+
+        expect(response).to have_http_status(400)
+      end
+      it "returns an object of errors of JSON" do
+        put "/lead_email/#{@resp_lead_email["resp"]["id"]}", params: @update_invalid_params
+        resp_json = JSON.parse(response.body)
+
+        expect(resp_json["resp"]).to include("email")
+        expect(resp_json["resp"]).to_not eq({})
+      end
+    end
+    context "request fails(invalid id)" do
+      it "returns a 404 status" do
+        put "/lead_email/#{@resp_lead_email["resp"]["id"] + 1}", params: @update_valid_params
+
+        expect(response).to have_http_status(404)
+      end
+      it "returns an error message on JSON" do
+        put "/lead_email/#{@resp_lead_email["resp"]["id"] + 1}", params: @update_valid_params
+        resp_json = JSON.parse(response.body)
+
+        expect(resp_json["resp"]).to eq("lead email can't be found")
+      end
+    end
+  end
+  describe "DELETE /lead_email/:id" do
+    before(:each) do
+      post "/lead_emails", params: @lead_email_params
+      @resp_lead_email = JSON.parse(response.body)
+    end
+    context "request is successful" do
+      it "returns a 200 status" do
+        delete "/lead_email/#{@resp_lead_email["resp"]["id"]}"
+
+        expect(response).to have_http_status(200)
+      end
+      it "returns a confirmatino message on JSON" do
+        delete "/lead_email/#{@resp_lead_email["resp"]["id"]}"
+        resp_json = JSON.parse(response.body)
+
+        expect(resp_json["resp"]).to eq("lead email has been deleted")
+      end
+    end
+    context "request fails" do
+      it "returns a 404 status" do
+        delete "/lead_email/#{@resp_lead_email["resp"]["id"] + 1}"
+
+        expect(response).to have_http_status(404)
+      end
+      it "returns an error message on JSON" do
+        delete "/lead_email/#{@resp_lead_email["resp"]["id"] + 1}"
+        resp_json = JSON.parse(response.body)
+
+        expect(resp_json["resp"]).to eq("lead email can't be found")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Key Objectives 
=============================== 
***Objectives***: Generate the LeadEmail controller, LeadEmail serializer, add the necessary method, add the necessary routes, write the tests and write methods

Analysis
=============================== 
- ***What are the necessary methods for this controller?***
- Create, show, update, destroy

- ***What are the tests for the create method?***
 - POST /lead_emails
   - request is successful
     - returns a 201 status
     - returns an instance of the LeadEmail model on JSON
     - saves the lead_email on the DB
   - request fails
     - returns a 400 status
     - returns an object of errors on JSON

- ***What are the tests for the show method?***
 - GET /lead_email/:id
   - request is successful
     - returns a 200 status
     - returns an instance of the LeadEmail model on JSON based on the id provided
   - request fails
     - returns a 404 status
     - returns an error message on JSON

- ***What are the tests for the update method?***
 - PUT /lead_email/:id
   - request is successful
     - returns a 200 status
     - returns the updated instance of the LeadEmail model on JSON
   - request fails(invalid params)
     - returns a 400 status
     - returns an object of errors of JSON
   - request fails(invalid id)
     - returns a 404 status
     - returns an error message on JSON

- ***What are the tests for the destroy method?***
 - DELETE /lead_email/:id
   - request is successful
     - returns a 200 status
     - returns a confirmatino message on JSON
   - request fails
     - returns a 404 status
     - returns an error message on JSON