### PR TITLE
Fix bcrypt

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -48,8 +48,8 @@ class Api::UsersController < ApplicationController
     params.permit(
       :username,
       :email,
-      :password_digest,
-      :password_digest_confirmation,
+      :password,
+      :password_confirmation,
       :first_name,
       :last_name,
       :city,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   validates_associated :job_positions 
 
   # Global validations
-  validates :username, :email, :password_digest, :password_digest_confirmation, :first_name, :last_name, :city, :state, :zipcode, { 
+  validates :username, :email, :password, :password_confirmation, :first_name, :last_name, :city, :state, :zipcode, { 
     presence: true 
   }
 
@@ -29,14 +29,14 @@ class User < ApplicationRecord
             }
 
   # password_digest validations
-  validates :password_digest, {
+  validates :password, {
               confirmation: true,
               length: { within: 8..25 },
             }
-  validates :password_digest, { format: { with: /[a-z]+/, message: "must contain at least one lowercase letter" } }
-  validates :password_digest, { format: { with: /[A-Z]+/, message: "must contain at least one uppercase letter" } }
-  validates :password_digest, { format: { with: /\d+/, message: "must contain at least one digit" } }
-  validates :password_digest, { format: { with: /[^A-Za-z0-9]+/, message: "must contain at least one special character" } }
+  validates :password, { format: { with: /[a-z]+/, message: "must contain at least one lowercase letter" } }
+  validates :password, { format: { with: /[A-Z]+/, message: "must contain at least one uppercase letter" } }
+  validates :password, { format: { with: /\d+/, message: "must contain at least one digit" } }
+  validates :password, { format: { with: /[^A-Za-z0-9]+/, message: "must contain at least one special character" } }
 
   # first_name & last_name validations
   validates :first_name, :last_name, {

--- a/spec/instance_helper.rb
+++ b/spec/instance_helper.rb
@@ -5,8 +5,8 @@ module InstanceHelper
   @@user_params = {
     "username" => "fernandocgomez",
     "email" => "fernandocgomez@live.com",
-    "password_digest" => "Ilovemytacos32%",
-    "password_digest_confirmation" => "Ilovemytacos32%",
+    "password" => "Ilovemytacos32%",
+    "password_confirmation" => "Ilovemytacos32%",
     "first_name" => "Fernando",
     "last_name" => "Gomez",
     "city" => "Houston",
@@ -28,8 +28,8 @@ module InstanceHelper
 
   def get_user_matcher
     matcher = @@user_params.clone
-    matcher.except!("password_digest")
-    matcher.except!("password_digest_confirmation")
+    matcher.except!("password")
+    matcher.except!("password_confirmation")
     matcher
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -64,59 +64,59 @@ RSpec.describe User, type: :model do
       end
     end
 
-    describe "password_digest" do
+    describe "password" do
       it "must be presence" do
         expect(subject).to be_valid
-        subject.password_digest = nil
+        subject.password = nil
         expect(subject).to_not be_valid
       end
 
       it "must be at least 8 characters" do
         expect(subject).to be_valid
-        subject.password_digest = "Ilovfe"
+        subject.password = "Ilovfe"
         expect(subject).to_not be_valid
       end
       it "must be a maximum of 25 characters" do
         expect(subject).to be_valid
-        subject.password_digest = "Ilovemytacos32%ferferferferferferferferferfer"
+        subject.password = "Ilovemytacos32%ferferferferferferferferferfer"
         expect(subject).to_not be_valid
       end
 
       it "must contain at least one special character" do
         expect(subject).to be_valid
-        subject.password_digest = "Ilovemytacos32"
+        subject.password = "Ilovemytacos32"
         expect(subject).to_not be_valid
       end
 
       it "must contain at least one lowercase letter" do
         expect(subject).to be_valid
-        subject.password_digest = "ILOVEMYTACOS32%"
+        subject.password = "ILOVEMYTACOS32%"
         expect(subject).to_not be_valid
       end
 
       it "must contain at least one uppercase letter" do
         expect(subject).to be_valid
-        subject.password_digest = "ilovemytacos32%"
+        subject.password = "ilovemytacos32%"
         expect(subject).to_not be_valid
       end
 
       it "must contain at least one digit" do
         expect(subject).to be_valid
-        subject.password_digest = "Ilovemytacos%"
+        subject.password = "Ilovemytacos%"
         expect(subject).to_not be_valid
       end
     end
 
-    describe "password_digest_confirmation" do
+    describe "password_confirmation" do
       it "must be presence" do
         expect(subject).to be_valid
-        subject.password_digest_confirmation = nil
+        subject.password_confirmation = nil
         expect(subject).to_not be_valid
       end
 
-      it "must match with password_digest" do
+      it "must match with password" do
         expect(subject).to be_valid
-        subject.password_digest_confirmation = "Differentpassword%"
+        subject.password_confirmation = "Differentpassword%"
         expect(subject).to_not be_valid
       end
     end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -72,13 +72,15 @@ RSpec.describe "Users", type: :request do
       end
     end
   end
+
   describe "PUT /api/user/:id" do
     before(:each) do
       post "/api/users", params: @params
       @params = JSON.parse(response.body)
-      @update_params = { "username" => "Cristobal", "password_digest_confirmation" => "Ilovemytacos32%" }
-      @update_invalid_params = { "username" => nil, "password_digest_confirmation" => "Ilovemytacos32%" }
+      @update_params = { "username" => "Cristobal", "password" => "Ilovemytacos32%", "password_confirmation" => "Ilovemytacos32%" }
+      @update_invalid_params = { "username" => nil, "password" => "Ilovemytacos32%", "password_confirmation" => "Ilovemytacos32%" }
     end
+
     context "request is successful" do
       it "returns a 200 status" do
         put "/api/user/#{@params["resp"]["id"]}", params: @update_params
@@ -92,6 +94,7 @@ RSpec.describe "Users", type: :request do
         expect(resp_json["resp"]["username"]).to match(@update_params["username"])
       end
     end
+
     context "request fails(invalid paramas)" do
       it "returns a 400 status" do
         put "/api/user/#{@params["resp"]["id"]}", params: @update_invalid_params


### PR DESCRIPTION
Key Objectives 
=============================== 
***Objectives***: Find out why the passwords are not being hashed and fix it.

Analysis
=============================== 
- ***why bcrypt is not hashing password?***
- The reason why bcrypt is not hashing is that we are using the password_digest attribute on the controller when we should be only using the attribute password. Password_digest should be only on the migration file.

https://stackoverflow.com/questions/42359584/rails-not-able-to-save-users-password-bcrypt
