### PR TITLE
Hotfix/0047

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
     get "lead/:id" => "leads#show"
     put "lead/:id" => "leads#update"
     delete "lead/:id" => "leads#destroy"
+    put "move_lead_to_other_column/:id" => "leads#move_lead_to_other_column"
 
     post "columns" => "columns#create"
     put "column/:id" => "columns#update"

--- a/spec/requests/columns_request_spec.rb
+++ b/spec/requests/columns_request_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Columns", type: :request do
   let(:column) { create(:column, board_id: board.id) }
 
   describe "#create" do
+
     context "when request success" do
       before(:each) do
         post "/api/columns", params: params, headers: token
@@ -33,6 +34,7 @@ RSpec.describe "Columns", type: :request do
         expect(Column.count).to eql(1)
       end
     end
+
     context 'when a new record is created' do
       before(:each) do
         post "/api/columns", params: params, headers: token
@@ -43,6 +45,7 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json["position"]).to eql(1)
       end
     end
+
     context "when request fails becuase of invalid params" do
       before(:each) do
         post "/api/columns", params: invalid_params, headers: token
@@ -56,6 +59,7 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json).to include("name")
       end
     end
+
     context 'when user tries to create a column not associated with its board' do
       before(:each) do
         post "/api/columns", params: params, headers: other_user_token
@@ -68,14 +72,16 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json).to match("you can not create a column that is not associated with one of yours boards without being an admin")
       end
     end
+
   end
 
   describe "#update" do
-    before(:each) do
-      put "/api/column/#{column.id}", params: update_params, headers: token
-      @resp_json = parse_resp_on_json(response)
-    end
+
     context "when request success" do
+      before(:each) do
+        put "/api/column/#{column.id}", params: update_params, headers: token
+        @resp_json = parse_resp_on_json(response)
+      end
       it "returns a 200 status" do
         expect(response).to have_http_status(200)
       end
@@ -85,6 +91,7 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json).to match(matcher)
       end
     end
+
     context "when request fails becuase of an invalid id" do
       before(:each) do
         put "/api/column/#{column.id + 1}", params: update_params, headers: token
@@ -97,6 +104,7 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json).to eql("column can't be found")
       end
     end
+
     context "when request fails becuase of invalid params" do
       before(:each) do
         put "/api/column/#{column.id}", params: invalid_update_params, headers: token
@@ -110,6 +118,7 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json).to include("name")
       end
     end
+
     context 'when user tries to update a column not associated with his board' do
       before(:each) do
         put "/api/column/#{column.id}", params: update_params, headers: other_user_token
@@ -122,7 +131,8 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json).to match("you can not update a column that is not associated with one of yours boards without being an admin")
       end
     end
-    context 'when position is updated to a greater value' do
+
+    context 'when position is updated to a higher value' do
       before(:each) do
         @column2 = create(:column, name: "My second column", position: 1, board_id: board.id)
         @column3 = create(:column, name: "My third column", position: 2, board_id: board.id)
@@ -134,6 +144,7 @@ RSpec.describe "Columns", type: :request do
         expect(Column.find_by_id(@column3.id).position).to eq(1)
       end
     end
+
     context 'when the position is updated to a lower value' do
       before(:each) do
         @column1 = create(:column, name: "My first column", position: 0, board_id: board.id)
@@ -147,6 +158,7 @@ RSpec.describe "Columns", type: :request do
         expect(Column.find_by_id(@column1.id).position).to eq(1)
       end
     end
+
     context 'when the position is updated to the same value' do
       before(:each) do
         put "/api/column/#{column.id}", params: { "position" => 0 }, headers: token
@@ -159,9 +171,11 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json).to match("column has the same position value")
       end
     end
+
   end
 
   describe "#destroy" do
+
     context "when request is successful" do
       before(:each) do
         delete "/api/column/#{column.id}", headers: token
@@ -177,6 +191,7 @@ RSpec.describe "Columns", type: :request do
         expect(Column.count).to eq(0)
       end
     end
+
     context "when request fails because of an invalid id" do
       before(:each) do
         delete "/api/column/#{column.id + 1}", headers: token
@@ -189,6 +204,7 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json).to match("column can't be found")
       end
     end
+
     context 'when user tries to delete a column not associated with his board' do
       before(:each) do
         delete "/api/column/#{column.id}", headers: other_user_token
@@ -201,6 +217,7 @@ RSpec.describe "Columns", type: :request do
         expect(@resp_json).to match("you can not delete a column that is not associated with one of yours boards without being an admin")
       end
     end
+
     context 'when a column is deleted' do
       before(:each) do
         @column3 = create(:column, name: "My third column", position: 2, board_id: board.id)
@@ -215,5 +232,6 @@ RSpec.describe "Columns", type: :request do
         expect(Column.find_by_id(@column4.id).position).to eq(2)
       end
     end
+
   end
 end

--- a/spec/requests/leads_request_spec.rb
+++ b/spec/requests/leads_request_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe "Leads", type: :request do
   let(:other_user_board) { create(:board, user_id: other_user.id) }
 
   let(:column) { create(:column, board_id: board.id) }
+  let(:column2) { create(:column, name: "my second column", board_id: board.id) }
   let(:other_user_column) { create(:column, board_id: other_user_board.id) }
 
   let(:company) { create(:company, user_id: user.id) }
@@ -20,6 +21,7 @@ RSpec.describe "Leads", type: :request do
   let(:invalid_params) { get_lead_params("invalid", column.id, company.id) }
   let(:update_params) { { "first_name" => "Juan", "position" => 0 } }
   let(:invalid_update_params) { { "first_name" => nil } }
+  let(:move_params) { { "position" => 1, "column_id" =>  column2.id } }
 
   let(:lead) { create(:lead, column_id: column.id, company_id: company.id) }
 
@@ -250,6 +252,18 @@ RSpec.describe "Leads", type: :request do
       end
     end
 
+    context 'when a record is deleted' do
+      before(:each) do
+        @lead_position_1 = create(:lead, column_id: column.id, company_id: company.id, position: 1)
+        @lead_position_2 = create(:lead, column_id: column.id, company_id: company.id, position: 2)
+        delete "/api/lead/#{lead.id}", headers: token
+      end
+      it 'ajustes the position of the leads after the one is deleted by subsctracting 1' do
+        expect(Lead.find_by_id(@lead_position_1.id).position).to eq(0)
+        expect(Lead.find_by_id(@lead_position_2.id).position).to eq(1)
+      end
+    end
+
     context "when request fails becuase of an invalid id" do
       before(:each) do
         delete "/api/lead/#{lead.id + 1}", headers: token
@@ -277,5 +291,67 @@ RSpec.describe "Leads", type: :request do
     end
 
   end
+
+  describe '#move_lead_to_other_column' do
+
+    context 'when a lead is moved to another column succesfully' do
+      before(:each) do
+        @column1_lead_position_1 = create(:lead, column_id: column.id, company_id: company.id, position: 1)
+        @column1_lead_position_2 = create(:lead, column_id: column.id, company_id: company.id, position: 2)
+        @column2_lead_position_0 = create(:lead, column_id: column2.id, company_id: company.id, position: 0)
+        @column2_lead_position_1 = create(:lead, column_id: column2.id, company_id: company.id, position: 1)
+        @column2_lead_position_2 = create(:lead, column_id: column2.id, company_id: company.id, position: 2)
+        put "/api/move_lead_to_other_column/#{lead.id}", params: move_params, headers: token
+        # let(:move_params) { { "position" => 1, "column_id" =>  column2.id } }
+        @resp_json = parse_resp_on_json(response)
+      end
+      it 'returns a 200 status' do
+        expect(response).to have_http_status(200)
+      end
+      it 'updates the lead column_id to the column_id that is being moved to' do
+        expect(@resp_json["column_id"]).to eq(column2.id)
+      end
+      it 'updates the position to the new position on the column that is being moved to' do
+        expect(@resp_json["position"]).to eq(1)
+      end
+      it 'updates the other leads position on the new column based where this lead is dropped' do
+        expect(Lead.find_by_id(@column2_lead_position_0.id).position).to eq(0)
+        expect(Lead.find_by_id(@column2_lead_position_1.id).position).to eq(2)
+        expect(Lead.find_by_id(@column2_lead_position_2.id).position).to eq(3)
+      end
+      it 'adjusts the position of the other leads on column from where was moved' do
+        expect(Lead.find_by_id(@column1_lead_position_1.id).position).to eq(0)
+        expect(Lead.find_by_id(@column1_lead_position_2.id).position).to eq(1)
+      end
+    end
+
+    context 'when lead id can not be found on the DB' do
+      before(:each) do
+        put "/api/move_lead_to_other_column/#{lead.id + 1}", params: move_params, headers: token
+        @resp_json = parse_resp_on_json(response)
+      end
+      it 'returns a 404 status' do
+        expect(response).to have_http_status(404)
+      end
+      it 'returns an error message on JSON' do
+        expect(@resp_json).to match("lead can't be found")
+      end
+    end
+
+    context 'when user tries to move a lead not associated with its account' do
+      before(:each) do
+        put "/api/move_lead_to_other_column/#{lead.id}", params: move_params, headers: other_user_token
+        @resp_json = parse_resp_on_json(response)
+      end
+      it "returns a 401 status" do
+        expect(response).to have_http_status(401)
+      end
+      it "returns an error message on JSON" do
+        expect(@resp_json).to match("you can not move a lead that is not associated with one of yours columns without being an admin")
+      end
+    end
+
+  end
+
 end
 


### PR DESCRIPTION
Key Objectives 
=============================== 
***Objectives***: We need to set the default position when a new lead is created, updated and deleted. 
We can take the column controller as a reference since it is the same concept. 

- Set the default position when a new lead is created
- Update position the position of a lead and the other lead position
- Update the position of the other lead when a lead is deleted

Analysis
=============================== 
- ***How can we add a default position to a lead when is created?***
 - We can take the number of lead associated with its column and subtract 1.
- ***How can we update the position of a lead and the other leads associated to a particular column?***
 - We need to take the lead as a reference and the new position then update the lead to the new position and all the lead on that range depending on if the lead increase on position or decrease. 
- ***How can we update the lead's column id?***
 - We need to locate the column using the lead, then remove the lead from the column, update the other leads. Then Add the lead to the new column and update the position attribute for the lead and all the leads associated