### PR TITLE
Config CORS

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,11 @@ module SmartJobShearchingApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    Rails.application.config.middleware.insert_before 0, Rack::Cors do
+      allow do
+        origins '*'
+        resource '*', headers: :any, methods: [:get, :post, :patch, :put, :delete]
+      end
+    end
   end
 end


### PR DESCRIPTION
Key Objectives 
=============================== 
***Objectives***: Make the API accessible from any origin at the moment. After we have the domain for our website and we figure how to set the origin on the google extension, we can change that.
